### PR TITLE
Use allocator traits to adapt pointer type (e.g. fancy pointers) based on allocator

### DIFF
--- a/include/compact_iterator.hpp
+++ b/include/compact_iterator.hpp
@@ -1,12 +1,12 @@
 #ifndef __COMPACT_ITERATOR_H__
 #define __COMPACT_ITERATOR_H__
 
+#include <climits>
+#include <cstddef>
 #include <iterator>
 #include <memory>
-#include <type_traits>
-#include <cstddef>
-#include <climits>
 #include <ostream>
+#include <type_traits>
 
 #if __cplusplus >= 202002L
 #include <compare>
@@ -16,10 +16,9 @@
 #include "parallel_iterator_traits.hpp"
 #include "prefetch_iterator_traits.hpp"
 
-
 namespace compact {
 // Number of bits in type t
-template<typename T>
+template <typename T>
 struct bitsof {
   static constexpr size_t val = sizeof(T) * CHAR_BIT;
 };
@@ -48,21 +47,21 @@ struct bitsof {
 //   bitsof<W>::val. Normally UB == bitsof<W>::val, but for some applications,
 //   saving a few bits in each word can be useful (for example to
 //   provide the compare and swap operation CAS).
-template<typename IDX, unsigned BITS = 0, typename W = uint64_t,
-         unsigned UB = bitsof<W>::val>
+template <typename IDX, unsigned BITS = 0, typename W = uint64_t, unsigned UB = bitsof<W>::val>
 class const_iterator;
-template<typename IDX, unsigned BITS = 0, typename W = uint64_t,
-         bool TS = false, unsigned UB = bitsof<W>::val>
+template <typename IDX, unsigned BITS = 0, typename W = uint64_t, bool TS = false, unsigned UB = bitsof<W>::val>
 class iterator;
 
 namespace iterator_imp {
-constexpr bool divides(unsigned a, unsigned b) { return b % a == 0; }
+constexpr bool divides(unsigned a, unsigned b) {
+  return b % a == 0;
+}
 
-template<typename W, bool TS>
-struct mask_store { }; // Store bits within a word masked
+template <typename W, bool TS>
+struct mask_store {};  // Store bits within a word masked
 
 // Getter / setter for BITS > 0 (number of bits known at compile time)
-template<typename IDX, unsigned BITS, typename W, unsigned UB>
+template <typename IDX, unsigned BITS, typename W, unsigned UB>
 struct gs {
   // Get a value at position p, offset o and b bits. There is no
   // multi-thread guarantee of consistency if another thread writes at
@@ -70,49 +69,54 @@ struct gs {
   // the value read may not be valid because of race conditions. See
   // fetch for that.
   static IDX get(const W* p, unsigned o) {
-    static constexpr size_t Wbits  = bitsof<W>::val;
+    static constexpr size_t Wbits = bitsof<W>::val;
     IDX res;
 
     constexpr W mask = ~(W)0 >> (Wbits - BITS);
-    if(UB == Wbits) {
+    if (UB == Wbits) {
       res = (*p >> o) & mask;
     } else {
       constexpr W hibit_mask = ~(W)0 >> (Wbits - UB);
       res = ((*p & hibit_mask) >> o) & mask;
     }
 
-    if(!divides(BITS, UB) && o + BITS > UB) {
-      const unsigned over  = o + BITS - UB;
-      const uint64_t mask  = ~(W)0 >> (Wbits - over);
-      res                 |= (*(p + 1) & mask) << (BITS - over);
+    if (!divides(BITS, UB) && o + BITS > UB) {
+      const unsigned over = o + BITS - UB;
+      const uint64_t mask = ~(W)0 >> (Wbits - over);
+      res |= (*(p + 1) & mask) << (BITS - over);
     }
-    if(std::is_signed<IDX>::value && (res & ((IDX)1 << (BITS - 1))))
+    if (std::is_signed<IDX>::value && (res & ((IDX)1 << (BITS - 1))))
       res |= ~static_cast<typename std::make_unsigned<IDX>::type>(0) << BITS;
 
     return res;
   }
-  static inline IDX get(const W* p, unsigned b, unsigned o) { return get(p, o); }
 
+  static inline IDX get(const W* p, unsigned b, unsigned o) {
+    return get(p, o);
+  }
 
   // Set a value at position p, offset o. TS set to true makes it safe
   // for multiple threads to write at different locations (same or
   // adjacent p and different o). It is still unsafe to use set with
   // multi-threads with same p and o. See push.
-  template<bool TS>
+  template <bool TS>
   static void set(IDX x, W* p, unsigned o) {
-    static constexpr size_t Wbits  = bitsof<W>::val;
-    static constexpr W      ubmask = ~(W)0 >> (Wbits - UB);
-    const W                 y      = x;
-    W                       mask   = ((~(W)0 >> (Wbits - BITS)) << o) & ubmask;
+    static constexpr size_t Wbits = bitsof<W>::val;
+    static constexpr W ubmask = ~(W)0 >> (Wbits - UB);
+    const W y = x;
+    W mask = ((~(W)0 >> (Wbits - BITS)) << o) & ubmask;
     mask_store<W, TS>::store(p, mask, y << o);
-    if(!divides(BITS, UB) && o + BITS > UB) {
+    if (!divides(BITS, UB) && o + BITS > UB) {
       unsigned over = o + BITS - UB;
-      mask              = ~(W)0 >> (Wbits - over);
+      mask = ~(W)0 >> (Wbits - over);
       mask_store<W, TS>::store(p + 1, mask, y >> (BITS - over));
     }
   }
-  template<bool TS>
-  static inline IDX set(IDX x, W* p, unsigned b, unsigned o) { return set(x, p, o); }
+
+  template <bool TS>
+  static inline IDX set(IDX x, W* p, unsigned b, unsigned o) {
+    return set(x, p, o);
+  }
 
   // Do a CAS at position p, offset o and number of bits b. Expect
   // value exp and set value x. It takes care of the tricky case when
@@ -122,12 +126,13 @@ struct gs {
   // the location is "dead" and other threads may be prevented from
   // making progress.
   static bool cas(const IDX x, const IDX exp, W* p, unsigned o) {
-    static_assert(UB < bitsof<W>::val, "The CAS operation is valid for a cas_vector (used bits less than bits in word)");
-    static constexpr size_t Wbits  = bitsof<W>::val;
-    static constexpr W      ubmask = ~(W)0 >> (Wbits - UB);
+    static_assert(UB < bitsof<W>::val,
+                  "The CAS operation is valid for a cas_vector (used bits less than bits in word)");
+    static constexpr size_t Wbits = bitsof<W>::val;
+    static constexpr W ubmask = ~(W)0 >> (Wbits - UB);
     static_assert(UB < Wbits, "Used bits must strictly less than bit size of W for CAS.");
-    if(divides(BITS, UB) || o + BITS <= UB) {
-      const W mask  = (~(W)0 >> (Wbits - BITS)) << o & ubmask;
+    if (divides(BITS, UB) || o + BITS <= UB) {
+      const W mask = (~(W)0 >> (Wbits - BITS)) << o & ubmask;
       return mask_store<W, true>::cas(p, mask, (W)x << o, (W)exp << o);
     }
 
@@ -136,14 +141,15 @@ struct gs {
     // in next word, then set MSB back to 0.
     static constexpr W msb = (W)1 << (Wbits - 1);
     W mask = (~(W)0 >> (Wbits - BITS)) << o;
-    if(!mask_store<W, true>::cas(p, mask, msb | ((W)x << o), ~msb & ((W)exp << o)))
+    if (!mask_store<W, true>::cas(p, mask, msb | ((W)x << o), ~msb & ((W)exp << o)))
       return false;
     const unsigned over = o + BITS - UB;
-    mask                = ~(W)0 >> (Wbits - over);
-    const bool     res  = mask_store<W, true>::cas(p + 1, mask, (W)x >> (BITS - over), (W)exp >> (BITS - over));
+    mask = ~(W)0 >> (Wbits - over);
+    const bool res = mask_store<W, true>::cas(p + 1, mask, (W)x >> (BITS - over), (W)exp >> (BITS - over));
     mask_store<W, true>::store(p, msb, 0);
     return res;
   }
+
   static inline bool cas(const IDX x, const IDX exp, W* p, unsigned b, unsigned o) {
     return cas(x, exp, p, o);
   }
@@ -160,85 +166,89 @@ struct gs {
   // succeeded). Otherwise, it returns false.
   static bool try_fetch(IDX& res, W* p, unsigned o) {
     static_assert(UB < bitsof<W>::val, "The fetch operation is valid for cas_vector (used bits less than bits in word");
-    static constexpr size_t Wbits     = bitsof<W>::val;
-    static constexpr W      msb       = (W)1 << (Wbits - 1);
-    const bool              need_lock = !(divides(BITS, UB) || o + BITS <= UB);
+    static constexpr size_t Wbits = bitsof<W>::val;
+    static constexpr W msb = (W)1 << (Wbits - 1);
+    const bool need_lock = !(divides(BITS, UB) || o + BITS <= UB);
 
-    if(need_lock) {
-      if(!mask_store<W, true>::cas(p, msb, msb, 0))
+    if (need_lock) {
+      if (!mask_store<W, true>::cas(p, msb, msb, 0))
         return false;
     }
 
     res = get(p, BITS, o);
 
-    if(need_lock)
+    if (need_lock)
       mask_store<W, true>::store(p, msb, 0);
     return true;
   }
 
   static inline IDX fetch(W* p, unsigned o) {
     IDX res;
-    while(!try_fetch(res, p, o)) { }
+    while (!try_fetch(res, p, o)) {}
     return res;
   }
-  static inline IDX fetch(W* p, unsigned b, unsigned o) { return fetch(p, o); }
+
+  static inline IDX fetch(W* p, unsigned b, unsigned o) {
+    return fetch(p, o);
+  }
 
   // Push value y at position p, offset o and number of bits b. This
   // can be used when multiple threads may update the same position
   // (p,o,b) with cas operations. See fetch for details
   static bool try_push(IDX y, W* p, unsigned o) {
     static_assert(UB < bitsof<W>::val, "The push operation is valid for cas_vector (used bits less than bits in word");
-    static constexpr size_t Wbits     = bitsof<W>::val;
-    static constexpr W      msb       = (W)1 << (Wbits - 1);
-    const bool              need_lock = !(divides(BITS, UB) || o + BITS <= UB);
+    static constexpr size_t Wbits = bitsof<W>::val;
+    static constexpr W msb = (W)1 << (Wbits - 1);
+    const bool need_lock = !(divides(BITS, UB) || o + BITS <= UB);
 
-    if(need_lock) {
-      if(!mask_store<W, true>::cas(p, msb, msb, 0))
+    if (need_lock) {
+      if (!mask_store<W, true>::cas(p, msb, msb, 0))
         return false;
     }
 
     set<true>(y, p, o);
 
-    if(need_lock)
+    if (need_lock)
       mask_store<W, true>::store(p, msb, 0);
     return true;
   }
+
   static inline void push(IDX y, W* p, unsigned o) {
-    while(!try_push(y, p, o)) { }
+    while (!try_push(y, p, o)) {}
   }
 };
 
 // gs implementation for number of bits known at runtime (BITS == 0).
 //
 // XXX: too much code duplication with non-specialized version of gs. Improve!
-template<typename IDX, typename W, unsigned UB>
+template <typename IDX, typename W, unsigned UB>
 struct gs<IDX, 0, W, UB> {
   static IDX get(const W* p, unsigned b, unsigned o) {
-    static constexpr size_t Wbits  = bitsof<W>::val;
-    static constexpr W      ubmask = ~(W)0 >> (Wbits - UB);
-    W                       mask   = ((~(W)0 >> (Wbits - b)) << o) & ubmask;
-    IDX                     res    = (*p & mask) >> o;
-    if(o + b > UB) {
-      const unsigned over  = o + b - UB;
-      mask                     = ~(W)0 >> (Wbits - over);
-      res                     |= (*(p + 1) & mask) << (b - over);
+    static constexpr size_t Wbits = bitsof<W>::val;
+    static constexpr W ubmask = ~(W)0 >> (Wbits - UB);
+    W mask = ((~(W)0 >> (Wbits - b)) << o) & ubmask;
+    IDX res = (*p & mask) >> o;
+    if (o + b > UB) {
+      const unsigned over = o + b - UB;
+      mask = ~(W)0 >> (Wbits - over);
+      res |= (*(p + 1) & mask) << (b - over);
     }
-    if(std::is_signed<IDX>::value && res & ((IDX)1 << (b - 1)))
+    if (std::is_signed<IDX>::value && res & ((IDX)1 << (b - 1)))
       res |= ~(IDX)0 << b;
 
     return res;
   }
 
-  template<bool TS>
+  template <bool TS>
   static void set(IDX x, W* p, unsigned b, unsigned o) {
-    static constexpr size_t Wbits  = bitsof<W>::val;
-    static constexpr W      ubmask = ~(W)0 >> (Wbits - UB);
-    const W                 y      = x;
-    W                       mask   = ((~(W)0 >> (Wbits - b)) << o) & ubmask;
+    static constexpr size_t Wbits = bitsof<W>::val;
+    static constexpr W ubmask = ~(W)0 >> (Wbits - UB);
+    const W y = x;
+    W mask = ((~(W)0 >> (Wbits - b)) << o) & ubmask;
     mask_store<W, TS>::store(p, mask, y << o);
-    if(o + b > UB) {
+    if (o + b > UB) {
       unsigned over = o + b - UB;
-      mask              = ~(W)0 >> (Wbits - over);
+      mask = ~(W)0 >> (Wbits - over);
       mask_store<W, TS>::store(p + 1, mask, y >> (b - over));
     }
   }
@@ -251,12 +261,13 @@ struct gs<IDX, 0, W, UB> {
   // location is "dead" and other threads maybe prevented from making
   // progress.
   static bool cas(const IDX x, const IDX exp, W* p, unsigned b, unsigned o) {
-    static_assert(UB < bitsof<W>::val, "The CAS operation is valid for a cas_vector (used bits less than bits in word)");
-    static constexpr size_t Wbits  = bitsof<W>::val;
-    static constexpr W      ubmask = ~(W)0 >> (Wbits - UB);
+    static_assert(UB < bitsof<W>::val,
+                  "The CAS operation is valid for a cas_vector (used bits less than bits in word)");
+    static constexpr size_t Wbits = bitsof<W>::val;
+    static constexpr W ubmask = ~(W)0 >> (Wbits - UB);
     static_assert(UB < Wbits, "Used bits must strictly less than bit size of W for CAS.");
-    if(o + b <= UB) {
-      const W mask  = (~(W)0 >> (Wbits - b)) << o & ubmask;
+    if (o + b <= UB) {
+      const W mask = (~(W)0 >> (Wbits - b)) << o & ubmask;
       return mask_store<W, true>::cas(p, mask, (W)x << o, (W)exp << o);
     }
 
@@ -265,11 +276,11 @@ struct gs<IDX, 0, W, UB> {
     // in next word, then set MSB back to 0.
     static constexpr W msb = (W)1 << (Wbits - 1);
     W mask = (~(W)0 >> (Wbits - b)) << o;
-    if(!mask_store<W, true>::cas(p, mask, msb | ((W)x << o), ~msb & ((W)exp << o)))
+    if (!mask_store<W, true>::cas(p, mask, msb | ((W)x << o), ~msb & ((W)exp << o)))
       return false;
     const unsigned over = o + b - UB;
-    mask                    = ~(W)0 >> (Wbits - over);
-    const bool         res  = mask_store<W, true>::cas(p + 1, mask, (W)x >> (b - over), (W)exp >> (b - over));
+    mask = ~(W)0 >> (Wbits - over);
+    const bool res = mask_store<W, true>::cas(p + 1, mask, (W)x >> (b - over), (W)exp >> (b - over));
     mask_store<W, true>::store(p, msb, 0);
     return res;
   }
@@ -287,25 +298,25 @@ struct gs<IDX, 0, W, UB> {
   static bool try_fetch(IDX& res, W* p, unsigned b, unsigned o) {
     static_assert(UB < bitsof<W>::val, "The fetch operation is valid for cas_vector (used bits less than bits in word");
 
-    static constexpr size_t Wbits     = bitsof<W>::val;
-    static constexpr W      msb       = (W)1 << (Wbits - 1);
-    const bool              need_lock = !(divides(b, UB) || o + b <= UB);
+    static constexpr size_t Wbits = bitsof<W>::val;
+    static constexpr W msb = (W)1 << (Wbits - 1);
+    const bool need_lock = !(divides(b, UB) || o + b <= UB);
 
-    if(need_lock) {
-      if(!mask_store<W, true>::cas(p, msb, msb, 0))
+    if (need_lock) {
+      if (!mask_store<W, true>::cas(p, msb, msb, 0))
         return false;
     }
 
     res = get(p, b, o);
 
-    if(need_lock)
+    if (need_lock)
       mask_store<W, true>::store(p, msb, 0);
     return true;
   }
 
   static inline IDX fetch(W* p, unsigned b, unsigned o) {
     IDX res;
-    while (!try_fetch(res, p, b, o)) { }
+    while (!try_fetch(res, p, b, o)) {}
     return res;
   }
 
@@ -314,23 +325,24 @@ struct gs<IDX, 0, W, UB> {
   // (p,o,b) with cas operations. See fetch for details
   static bool try_push(IDX y, W* p, unsigned b, unsigned o) {
     static_assert(UB < bitsof<W>::val, "The push operation is valid for cas_vector (used bits less than bits in word");
-    static constexpr size_t Wbits     = bitsof<W>::val;
-    static constexpr W      msb       = (W)1 << (Wbits - 1);
-    const bool              need_lock = !(divides(b, UB) || o + b <= UB);
+    static constexpr size_t Wbits = bitsof<W>::val;
+    static constexpr W msb = (W)1 << (Wbits - 1);
+    const bool need_lock = !(divides(b, UB) || o + b <= UB);
 
-    if(need_lock) {
-      if(!mask_store<W, true>::cas(p, msb, msb, 0))
+    if (need_lock) {
+      if (!mask_store<W, true>::cas(p, msb, msb, 0))
         return false;
     }
 
     set<true>(y, p, b, o);
 
-    if(need_lock)
+    if (need_lock)
       mask_store<W, true>::store(p, msb, 0);
     return true;
   }
+
   static inline void push(IDX y, W* p, unsigned b, unsigned o) {
-    while(!try_push(y, p, b, o)) { }
+    while (!try_push(y, p, b, o)) {}
   }
 };
 
@@ -338,44 +350,36 @@ struct gs<IDX, 0, W, UB> {
 // fetch and push when the number of used bits is less than the number
 // of bits in the word. (e.g., cas_vector iterator).
 struct gf_sp_helper {
-  template<typename IDX, unsigned BITS, typename W, unsigned UB, typename... Args>
-  static inline
-  typename std::enable_if<UB == bitsof<W>::val, IDX>::type
-  getfetch(const W* p, Args&&... args) {
+  template <typename IDX, unsigned BITS, typename W, unsigned UB, typename... Args>
+  static inline typename std::enable_if<UB == bitsof<W>::val, IDX>::type getfetch(const W* p, Args&&... args) {
     return gs<IDX, BITS, W, UB>::get(p, std::forward<Args>(args)...);
   }
 
-  template<typename IDX, unsigned BITS, typename W, unsigned UB, typename... Args>
-  static inline
-  typename std::enable_if<UB != bitsof<W>::val, IDX>::type
-  getfetch(const W* p, Args&&... args) {
+  template <typename IDX, unsigned BITS, typename W, unsigned UB, typename... Args>
+  static inline typename std::enable_if<UB != bitsof<W>::val, IDX>::type getfetch(const W* p, Args&&... args) {
     return gs<IDX, BITS, W, UB>::fetch(const_cast<W*>(p), std::forward<Args>(args)...);
   }
 
-  template<typename IDX, unsigned BITS, typename W, unsigned UB, typename... Args>
-  static inline
-  typename std::enable_if<UB == bitsof<W>::val, void>::type
-  setpush(IDX y, W* p, Args&&... args) {
+  template <typename IDX, unsigned BITS, typename W, unsigned UB, typename... Args>
+  static inline typename std::enable_if<UB == bitsof<W>::val, void>::type setpush(IDX y, W* p, Args&&... args) {
     gs<IDX, BITS, W, UB>::template set<true>(y, p, std::forward<Args>(args)...);
   }
 
-  template<typename IDX, unsigned BITS, typename W, unsigned UB, typename... Args>
-  static inline
-  typename std::enable_if<UB != bitsof<W>::val, void>::type
-  setpush(IDX y, W* p, Args&&... args) {
+  template <typename IDX, unsigned BITS, typename W, unsigned UB, typename... Args>
+  static inline typename std::enable_if<UB != bitsof<W>::val, void>::type setpush(IDX y, W* p, Args&&... args) {
     gs<IDX, BITS, W, UB>::push(y, p, std::forward<Args>(args)...);
   }
 };
 
 // Mask store, depending on the thread safety guarantee
-template<typename W>
+template <typename W>
 struct mask_store<W, false> {
   static inline void store(W* p, W mask, W val) {
     *p = (*p & ~mask) | (val & mask);
   }
 };
 
-template<typename W>
+template <typename W>
 struct mask_store<W, true> {
   static void store(W* p, W mask, W val) {
     W cval = *p, oval;
@@ -383,7 +387,7 @@ struct mask_store<W, true> {
       W nval = (cval & ~mask) | (val & mask);
       oval = cval;
       cval = __sync_val_compare_and_swap(p, oval, nval);
-    } while(cval != oval);
+    } while (cval != oval);
   }
 
   // Do a CAS at p and val, only in the bits covered by mask. It
@@ -393,13 +397,13 @@ struct mask_store<W, true> {
     W cval = *p, oval;
     val &= mask;
     exp &= mask;
-    if(val == exp)
+    if (val == exp)
       return (cval & mask) == exp;
-    while((cval & mask) == exp) {
+    while ((cval & mask) == exp) {
       W nval = (cval & ~mask) | val;
       oval = cval;
       cval = __sync_val_compare_and_swap(p, oval, nval);
-      if(cval == oval)
+      if (cval == oval)
         return true;
     }
     return false;
@@ -407,39 +411,37 @@ struct mask_store<W, true> {
 };
 
 // Replacement for the now deprecated (C++17) std::iterator
-template<typename T>
+template <typename T>
 struct iterator_types {
-  typedef T                               value_type;
-  typedef ptrdiff_t                       difference_type;
-  typedef T*                              pointer;
-  typedef T&                              reference;
+  typedef T value_type;
+  typedef ptrdiff_t difference_type;
+  typedef T* pointer;
+  typedef T& reference;
   typedef std::random_access_iterator_tag iterator_category;
 };
 
 // Base class for the iterators
-template<class Derived, typename IDX, unsigned BITS, typename W, unsigned UB>
+template <class Derived, typename IDX, unsigned BITS, typename W, unsigned UB>
 class common {
-public:
+ public:
   std::ostream& print(std::ostream& os) const {
     const Derived& self = *static_cast<const Derived*>(this);
     return os << '<' << (void*)self.m_ptr << '+' << self.m_offset << ',' << self.bits() << '>';
   }
 
-protected:
+ protected:
   static constexpr unsigned Wbits = bitsof<W>::val;
   // UB is the number of bits actually used in a word.
-  static_assert(UB <= Wbits,
-                "Number of used bits must be less than number of bits in a word");
-  static_assert(sizeof(IDX) <= sizeof(W),
-                "The size of integral type IDX must be less than the word type W");
+  static_assert(UB <= Wbits, "Number of used bits must be less than number of bits in a word");
+  static_assert(sizeof(IDX) <= sizeof(W), "The size of integral type IDX must be less than the word type W");
 
-public:
+ public:
   typedef typename iterator_types<IDX>::difference_type difference_type;
   static constexpr unsigned used_bits = UB;
 
   Derived& operator=(const Derived& rhs) {
     Derived& self = *static_cast<Derived*>(this);
-    self.m_ptr    = rhs.m_ptr;
+    self.m_ptr = rhs.m_ptr;
     self.m_offset = rhs.m_offset;
     self.m_bits(rhs.bits());
     return self;
@@ -447,7 +449,7 @@ public:
 
   Derived& operator=(std::nullptr_t p) {
     Derived& self = *static_cast<Derived*>(this);
-    self.m_ptr    = nullptr;
+    self.m_ptr = nullptr;
     self.m_offset = 0;
   }
 
@@ -462,13 +464,15 @@ public:
     const Derived& self = *static_cast<const Derived*>(this);
     const Derived& other = static_cast<const Derived&>(rhs);
     const auto ptr_cmp = self.m_ptr <=> other.m_ptr;
-    if(ptr_cmp != 0)
+    if (ptr_cmp != 0)
       return ptr_cmp;
     return self.m_offset <=> other.m_offset;
   }
+
   bool operator==(const common& rhs) const {
     return (*this <=> rhs) == 0;
   }
+
   bool operator==(std::nullptr_t p) const {
     const Derived& self = *static_cast<const Derived*>(this);
     return self.m_ptr == nullptr && self.m_offset == 0;
@@ -479,6 +483,7 @@ public:
     const Derived& self = *static_cast<const Derived*>(this);
     return self.m_ptr == rhs.m_ptr && self.m_offset == rhs.m_offset;
   }
+
   bool operator!=(const Derived& rhs) const {
     return !(*this == rhs);
   }
@@ -487,6 +492,7 @@ public:
     const Derived& self = *static_cast<const Derived*>(this);
     return self.m_ptr == nullptr && self.m_offset == 0;
   }
+
   bool operator!=(std::nullptr_t p) const {
     return !(*this == nullptr);
   }
@@ -495,13 +501,16 @@ public:
     const Derived& self = *static_cast<const Derived*>(this);
     return self.m_ptr < rhs.m_ptr || (self.m_ptr == rhs.m_ptr && self.m_offset < rhs.m_offset);
   }
+
   bool operator>(const Derived& rhs) const {
     const Derived& self = *static_cast<const Derived*>(this);
     return self.m_ptr > rhs.m_ptr || (self.m_ptr == rhs.m_ptr && self.m_offset > rhs.m_offset);
   }
+
   bool operator>=(const Derived& rhs) const {
     return !(*this < rhs);
   }
+
   bool operator<=(const Derived& rhs) const {
     return !(*this > rhs);
   }
@@ -510,12 +519,13 @@ public:
   Derived& operator++() {
     Derived& self = *static_cast<Derived*>(this);
     self.m_offset += self.bits();
-    if(self.m_offset >= UB) {
+    if (self.m_offset >= UB) {
       ++self.m_ptr;
       self.m_offset -= UB;
     }
     return self;
   }
+
   Derived operator++(int) {
     Derived res(*static_cast<Derived*>(this));
     ++*this;
@@ -524,13 +534,14 @@ public:
 
   Derived& operator--() {
     Derived& self = *static_cast<Derived*>(this);
-    if(self.bits() > self.m_offset) {
+    if (self.bits() > self.m_offset) {
       --self.m_ptr;
       self.m_offset += UB;
     }
     self.m_offset -= self.bits();
     return self;
   }
+
   Derived operator--(int) {
     Derived res(*static_cast<Derived*>(this));
     --*this;
@@ -538,16 +549,16 @@ public:
   }
 
   Derived& operator+=(difference_type n) {
-    Derived&     self    = *static_cast<Derived*>(this);
-    if(n < 0) {
+    Derived& self = *static_cast<Derived*>(this);
+    if (n < 0) {
       self -= -n;
       return self;
     }
 
-    const size_t nbbits  = self.bits() * n;
-    self.m_ptr          += nbbits / UB;
-    self.m_offset       += nbbits % UB;
-    if(self.m_offset >= UB) {
+    const size_t nbbits = self.bits() * n;
+    self.m_ptr += nbbits / UB;
+    self.m_offset += nbbits % UB;
+    if (self.m_offset >= UB) {
       ++self.m_ptr;
       self.m_offset -= UB;
     }
@@ -560,16 +571,16 @@ public:
   }
 
   Derived& operator-=(difference_type n) {
-    Derived&           self     = *static_cast<Derived*>(this);
-    if(n < 0) {
+    Derived& self = *static_cast<Derived*>(this);
+    if (n < 0) {
       self += -n;
       return self;
     }
 
-    const size_t      nbbits    = self.bits() * n;
-    self.m_ptr                 -= nbbits / UB;
-    const unsigned ooffset  = nbbits % UB;
-    if(ooffset > self.m_offset) {
+    const size_t nbbits = self.bits() * n;
+    self.m_ptr -= nbbits / UB;
+    const unsigned ooffset = nbbits % UB;
+    if (ooffset > self.m_offset) {
       --self.m_ptr;
       self.m_offset += UB;
     }
@@ -582,12 +593,12 @@ public:
     return res -= n;
   }
 
-  template<unsigned BB, typename DD>
+  template <unsigned BB, typename DD>
   difference_type operator-(const common<DD, IDX, BB, W, UB>& rhs_) const {
-    const Derived& self  = *static_cast<const Derived*>(this);
-    const DD&      rhs   = *static_cast<const DD*>(&rhs_);
-    ptrdiff_t      wdiff = (self.m_ptr - rhs.m_ptr) * UB;
-    if(self.m_offset < rhs.m_offset)
+    const Derived& self = *static_cast<const Derived*>(this);
+    const DD& rhs = *static_cast<const DD*>(&rhs_);
+    ptrdiff_t wdiff = (self.m_ptr - rhs.m_ptr) * UB;
+    if (self.m_offset < rhs.m_offset)
       wdiff += (ptrdiff_t)((UB + self.m_offset) - rhs.m_offset) - (ptrdiff_t)UB;
     else
       wdiff += self.m_offset - rhs.m_offset;
@@ -595,63 +606,67 @@ public:
   }
 
   IDX operator[](const difference_type n) const {
-    const Derived& self  = *static_cast<const Derived*>(this);
+    const Derived& self = *static_cast<const Derived*>(this);
     return *(self + n);
   }
 
   // Extra methods which are not part of an iterator interface
 
   const W* get_ptr() const {
-    const Derived& self  = *static_cast<const Derived*>(this);
+    const Derived& self = *static_cast<const Derived*>(this);
     return self.m_ptr;
   }
+
   unsigned get_offset() const {
-    const Derived& self  = *static_cast<const Derived*>(this);
+    const Derived& self = *static_cast<const Derived*>(this);
     return self.m_offset;
   }
+
   unsigned get_bits() const {
-    const Derived& self  = *static_cast<const Derived*>(this);
+    const Derived& self = *static_cast<const Derived*>(this);
     return self.bits();
   }
 
   // Get some number of bits
   W get_bits(unsigned bits) const {
-    const Derived& self  = *static_cast<const Derived*>(this);
+    const Derived& self = *static_cast<const Derived*>(this);
     return gs<W, BITS, W, UB>::get(self.m_ptr, bits, self.m_offset);
   }
 
   W get_bits(unsigned bits, unsigned offset) const {
-    const Derived& self  = *static_cast<const Derived*>(this);
+    const Derived& self = *static_cast<const Derived*>(this);
     return gs<W, BITS, W, UB>::get(self.m_ptr, bits, offset);
   }
 
-  template<bool TS = false>
+  template <bool TS = false>
   void set_bits(W x, unsigned bits) {
-    Derived& self  = *static_cast<Derived*>(this);
+    Derived& self = *static_cast<Derived*>(this);
     gs<W, BITS, W, UB>::set<TS>(x, self.m_ptr, bits, self.m_offset);
   }
 
   // Get, i.e., don't use fetch
   IDX get() const {
-    const Derived& self  = *static_cast<const Derived*>(this);
+    const Derived& self = *static_cast<const Derived*>(this);
     return gs<W, BITS, W, UB>::get(self.m_ptr, self.bits(), self.m_offset);
   }
 };
 
-template<typename W, int I = sizeof(W)>
+template <typename W, int I = sizeof(W)>
 struct swap_word_mask {
   static constexpr W value = swap_word_mask<W, I / 2>::value << (4 * I) | swap_word_mask<W, I / 2>::value;
 };
-template<typename W>
+
+template <typename W>
 struct swap_word_mask<W, 1> {
   static constexpr W value = 0x55;
 };
 
-template<typename W>
+template <typename W>
 inline W swap_word(W w) {
   return ((w & swap_word_mask<W>::value) << 1) | ((w & (swap_word_mask<W>::value << 1)) >> 1);
 }
-template<typename W>
+
+template <typename W>
 inline bool compare_swap_words(W w1, W w2) {
   w1 = swap_word(w1);
   w2 = swap_word(w2);
@@ -667,68 +682,77 @@ inline bool compare_swap_words(W w1, W w2) {
 // ** This code is kind of sick!
 
 //helper template, just converts its variadic arguments to array initializer list
-template<size_t... values> struct size_t_ary {static const size_t value[sizeof...(values)];};
-template<size_t... values> const size_t size_t_ary<values...>::value[] = {values...};
+template <size_t... values>
+struct size_t_ary {
+  static const size_t value[sizeof...(values)];
+};
 
-template<size_t X, size_t k = X, size_t... values>
-struct word_idx : word_idx <X, k-1, X / k, values...> {};
-template<size_t X, size_t... values>
+template <size_t... values>
+const size_t size_t_ary<values...>::value[] = {values...};
+
+template <size_t X, size_t k = X, size_t... values>
+struct word_idx : word_idx<X, k - 1, X / k, values...> {};
+
+template <size_t X, size_t... values>
 struct word_idx<X, 0, values...> : size_t_ary<(size_t)0, values...> {};
 
-template<size_t X, size_t k = X, size_t... values>
-struct word_bits : word_bits <X, k-1, k * (X / k), values...> {};
-template<size_t X, size_t... values>
+template <size_t X, size_t k = X, size_t... values>
+struct word_bits : word_bits<X, k - 1, k*(X / k), values...> {};
+
+template <size_t X, size_t... values>
 struct word_bits<X, 0, values...> : size_t_ary<(size_t)0, values...> {};
 
-template<typename Iterator>
-bool lexicographical_compare_n(Iterator first1, const size_t len1,
-                               Iterator first2, const size_t len2) {
+template <typename Iterator>
+bool lexicographical_compare_n(Iterator first1, const size_t len1, Iterator first2, const size_t len2) {
   static constexpr unsigned UB = Iterator::used_bits;
 
-  const auto bits            = first1.get_bits();
-  auto       left            = std::min(len1, len2) * bits;
-  const decltype(len1) Widx  = word_idx<UB>::value[bits];
+  const auto bits = first1.get_bits();
+  auto left = std::min(len1, len2) * bits;
+  const decltype(len1) Widx = word_idx<UB>::value[bits];
   const decltype(len1) Wbits = word_bits<UB>::value[bits];
 
-  for( ; left > Wbits; left -= Wbits, first1 += Widx, first2 += Widx) {
-    auto w1   = first1.get_bits(Wbits);
-    auto w2   = first2.get_bits(Wbits);
-    if(w1 != w2) return compare_swap_words(w1, w2);
+  for (; left > Wbits; left -= Wbits, first1 += Widx, first2 += Widx) {
+    auto w1 = first1.get_bits(Wbits);
+    auto w2 = first2.get_bits(Wbits);
+    if (w1 != w2)
+      return compare_swap_words(w1, w2);
   }
-  if(left > 0) {
-    auto w1   = first1.get_bits(left);
-    auto w2   = first2.get_bits(left);
-    if(w1 != w2) return compare_swap_words(w1, w2);
+  if (left > 0) {
+    auto w1 = first1.get_bits(left);
+    auto w2 = first2.get_bits(left);
+    if (w1 != w2)
+      return compare_swap_words(w1, w2);
   }
 
   return len1 < len2;
 }
 
-template<typename D, typename I, unsigned B, typename W, unsigned U>
+template <typename D, typename I, unsigned B, typename W, unsigned U>
 inline bool operator==(std::nullptr_t lfs, const common<D, I, B, W, U>& rhs) {
   return rhs.operator==(nullptr);
 }
 
-template<typename D, typename I, unsigned B, typename W, unsigned U>
+template <typename D, typename I, unsigned B, typename W, unsigned U>
 inline D operator+(typename common<D, I, B, W, U>::difference_type lhs, const common<D, I, B, W, U>& rhs) {
   return rhs + lhs;
 }
 
-template<typename D, typename I, unsigned B, typename W, unsigned U>
+template <typename D, typename I, unsigned B, typename W, unsigned U>
 inline std::ostream& operator<<(std::ostream& os, const common<D, I, B, W, U>& rhs) {
   return rhs.print(os);
 }
 
-template<class Derived,
-         typename IDX, unsigned BITS, typename W, bool TS = false, unsigned UB = bitsof<W>::val>
+template <class Derived, typename IDX, unsigned BITS, typename W, bool TS = false, unsigned UB = bitsof<W>::val>
 class lhs_setter_common {
-protected:
-  W*       m_ptr;
+ protected:
+  W* m_ptr;
   unsigned m_offset;
 
-public:
+ public:
   typedef compact::iterator<IDX, BITS, W, TS, UB> iterator;
-  lhs_setter_common(W* p, unsigned o) : m_ptr(p), m_offset(o) { }
+
+  lhs_setter_common(W* p, unsigned o) : m_ptr(p), m_offset(o) {}
+
   operator IDX() const {
     const Derived& self = *static_cast<const Derived*>(this);
     return gf_sp_helper::template getfetch<IDX, BITS, W, UB>(m_ptr, self.bits(), m_offset);
@@ -738,6 +762,7 @@ public:
     Derived& self = *static_cast<Derived*>(this);
     return iterator(m_ptr, self.bits(), m_offset);
   }
+
   inline bool cas(const IDX x, const IDX exp) {
     Derived& self = *static_cast<Derived*>(this);
     return gs<IDX, BITS, W, UB>::cas(x, exp, m_ptr, self.bits(), m_offset);
@@ -750,22 +775,22 @@ public:
   }
 };
 
-template<typename IDX, unsigned BITS, typename W, bool TS, unsigned UB>
+template <typename IDX, unsigned BITS, typename W, bool TS, unsigned UB>
 class lhs_setter;
 
-template<typename IDX, typename W, bool TS, unsigned UB>
-class lhs_setter<IDX, 0, W, TS, UB>
-  : public lhs_setter_common<lhs_setter<IDX, 0, W, TS, UB>, IDX, 0, W, TS, UB>
-{
+template <typename IDX, typename W, bool TS, unsigned UB>
+class lhs_setter<IDX, 0, W, TS, UB> : public lhs_setter_common<lhs_setter<IDX, 0, W, TS, UB>, IDX, 0, W, TS, UB> {
   typedef lhs_setter_common<lhs_setter<IDX, 0, W, TS, UB>, IDX, 0, W, TS, UB> super;
-  unsigned m_bits;                // number of bits in an integral type
+  unsigned m_bits;  // number of bits in an integral type
 
-public:
-  lhs_setter(W* p, int b, int o) : super(p, o), m_bits(b) { }
+ public:
+  lhs_setter(W* p, int b, int o) : super(p, o), m_bits(b) {}
+
   lhs_setter& operator=(const IDX x) {
     gf_sp_helper::template setpush<IDX, 0, W, UB>(x, super::m_ptr, m_bits, super::m_offset);
     return *this;
   }
+
   lhs_setter& operator=(const lhs_setter& rhs) {
     this->operator=((IDX)rhs);
     return *this;
@@ -776,28 +801,32 @@ public:
     gs<IDX, 0, W, UB>::template set<false>(x, super::m_ptr, bits(), super::m_offset);
     return *this;
   }
+
   // Use set, i.e., not push, but at least thread safe version
   lhs_setter& ts_set(const IDX x) {
     gs<IDX, 0, W, UB>::template set<true>(x, super::m_ptr, bits(), super::m_offset);
     return *this;
   }
 
-  unsigned bits() const { return m_bits; }
+  unsigned bits() const {
+    return m_bits;
+  }
 };
 
-template<typename IDX, unsigned BITS, typename W, bool TS, unsigned UB>
-class lhs_setter
-  : public lhs_setter_common<lhs_setter<IDX, BITS, W, TS, UB>, IDX, BITS, W, TS, UB>
-{
+template <typename IDX, unsigned BITS, typename W, bool TS, unsigned UB>
+class lhs_setter : public lhs_setter_common<lhs_setter<IDX, BITS, W, TS, UB>, IDX, BITS, W, TS, UB> {
   typedef lhs_setter_common<lhs_setter<IDX, BITS, W, TS, UB>, IDX, BITS, W, TS, UB> super;
 
-public:
-  lhs_setter(W* p, int o) : super(p, o) { }
-  lhs_setter(W* p, unsigned bits, int o) : super(p, o) { }
+ public:
+  lhs_setter(W* p, int o) : super(p, o) {}
+
+  lhs_setter(W* p, unsigned bits, int o) : super(p, o) {}
+
   lhs_setter& operator=(const IDX x) {
     gf_sp_helper::template setpush<IDX, BITS, W, UB>(x, super::m_ptr, super::m_offset);
     return *this;
   }
+
   lhs_setter& operator=(const lhs_setter& rhs) {
     this->operator=((IDX)rhs);
     return *this;
@@ -808,32 +837,33 @@ public:
     gs<IDX, 0, W, UB>::template set<false>(x, super::m_ptr, bits(), super::m_offset);
     return *this;
   }
+
   // Use set, i.e., not push, but at least thread safe version
   lhs_setter& ts_set(const IDX x) {
     gs<IDX, 0, W, UB>::template set<true>(x, super::m_ptr, bits(), super::m_offset);
     return *this;
   }
 
-  constexpr unsigned bits() const { return BITS; }
+  constexpr unsigned bits() const {
+    return BITS;
+  }
 };
 
-template<typename I, unsigned BITS, typename W, bool TS, unsigned UB>
+template <typename I, unsigned BITS, typename W, bool TS, unsigned UB>
 void swap(lhs_setter<I, BITS, W, TS, UB> x, lhs_setter<I, BITS, W, TS, UB> y) {
   I t = x;
   x = (I)y;
   y = t;
 }
 
-} // namespace iterator_imp
+}  // namespace iterator_imp
 
 // Specialization with BITS=0 (dynamic/runtime number of bits used)
-template<typename IDX, typename W, bool TS, unsigned UB>
-class iterator<IDX, 0, W, TS, UB> :
-    public iterator_imp::iterator_types<IDX>,
-    public iterator_imp::common<iterator<IDX, 0, W, TS, UB>, IDX, 0, W, UB>
-{
-  W*       m_ptr;
-  unsigned m_bits;                // number of bits in an integral type
+template <typename IDX, typename W, bool TS, unsigned UB>
+class iterator<IDX, 0, W, TS, UB> : public iterator_imp::iterator_types<IDX>,
+                                    public iterator_imp::common<iterator<IDX, 0, W, TS, UB>, IDX, 0, W, UB> {
+  W* m_ptr;
+  unsigned m_bits;  // number of bits in an integral type
   unsigned m_offset;
 
   friend class iterator<IDX, 0, W, !TS, UB>;
@@ -842,23 +872,27 @@ class iterator<IDX, 0, W, TS, UB> :
   friend class iterator_imp::common<const_iterator<IDX, 0, W, UB>, IDX, 0, W, UB>;
 
   typedef iterator_imp::iterator_types<IDX> super;
-public:
-  typedef typename super::value_type                  value_type;
-  typedef typename super::difference_type             difference_type;
-  typedef IDX                                         idx_type;
-  typedef W                                           word_type;
+
+ public:
+  typedef typename super::value_type value_type;
+  typedef typename super::difference_type difference_type;
+  typedef IDX idx_type;
+  typedef W word_type;
   typedef iterator_imp::lhs_setter<IDX, 0, W, TS, UB> lhs_setter_type;
 
   iterator() = default;
-  iterator(W* p, unsigned b, unsigned o)
-    : m_ptr(p), m_bits(b), m_offset(o) { }
-  template<unsigned BITS, bool TTS>
-  iterator(const iterator<IDX, BITS, W, TTS>& rhs)
-    : m_ptr(rhs.m_ptr), m_bits(rhs.m_bits), m_offset(rhs.m_offset) { }
-  iterator(std::nullptr_t)
-    : m_ptr(nullptr), m_bits(0), m_offset(0) { }
 
-  lhs_setter_type operator*() const { return lhs_setter_type(m_ptr, m_bits, m_offset); }
+  iterator(W* p, unsigned b, unsigned o) : m_ptr(p), m_bits(b), m_offset(o) {}
+
+  template <unsigned BITS, bool TTS>
+  iterator(const iterator<IDX, BITS, W, TTS>& rhs) : m_ptr(rhs.m_ptr), m_bits(rhs.m_bits), m_offset(rhs.m_offset) {}
+
+  iterator(std::nullptr_t) : m_ptr(nullptr), m_bits(0), m_offset(0) {}
+
+  lhs_setter_type operator*() const {
+    return lhs_setter_type(m_ptr, m_bits, m_offset);
+  }
+
   lhs_setter_type operator[](const difference_type n) const {
     return *(*this + n);
   }
@@ -869,18 +903,21 @@ public:
     return iterator_imp::gs<IDX, 0, W, UB>::cas(x, exp, m_ptr, m_bits, m_offset);
   }
 
-  unsigned bits() const { return m_bits; }
-protected:
-  void bits(unsigned b) { m_bits = b; }
+  unsigned bits() const {
+    return m_bits;
+  }
+
+ protected:
+  void bits(unsigned b) {
+    m_bits = b;
+  }
 };
 
-template<typename IDX, typename W, unsigned UB>
-class const_iterator<IDX, 0, W, UB> :
-  public iterator_imp::iterator_types<const IDX>,
-  public iterator_imp::common<const_iterator<IDX, 0, W, UB>, IDX, 0, W, UB>
-{
+template <typename IDX, typename W, unsigned UB>
+class const_iterator<IDX, 0, W, UB> : public iterator_imp::iterator_types<const IDX>,
+                                      public iterator_imp::common<const_iterator<IDX, 0, W, UB>, IDX, 0, W, UB> {
   const W* m_ptr;
-  unsigned m_bits;                // number of bits in an integral type
+  unsigned m_bits;  // number of bits in an integral type
   unsigned m_offset;
 
   friend class iterator<IDX, 0, W>;
@@ -889,36 +926,39 @@ class const_iterator<IDX, 0, W, UB> :
   friend class iterator_imp::common<const_iterator<IDX, 0, W, UB>, IDX, 0, W, UB>;
 
   typedef iterator_imp::iterator_types<IDX> super;
-public:
-  typedef typename super::value_type      value_type;
+
+ public:
+  typedef typename super::value_type value_type;
   typedef typename super::difference_type difference_type;
   typedef IDX idx_type;
-  typedef W   word_type;
-
+  typedef W word_type;
 
   const_iterator() = default;
-  const_iterator(const W* p, unsigned b, unsigned o)
-    : m_ptr(p), m_bits(b), m_offset(o) { }
-  const_iterator(const const_iterator& rhs)
-    : m_ptr(rhs.m_ptr), m_bits(rhs.m_bits), m_offset(rhs.m_offset) { }
-  template<unsigned BITS, bool TS>
-  const_iterator(const iterator<IDX, BITS, W, TS>& rhs)
-    : m_ptr(rhs.m_ptr), m_bits(rhs.m_bits), m_offset(rhs.m_offset) { }
-  const_iterator(std::nullptr_t)
-    : m_ptr(nullptr), m_bits(0), m_offset(0) { }
 
-  unsigned bits() const { return m_bits; }
-  void bits(unsigned b) { m_bits = b; }
+  const_iterator(const W* p, unsigned b, unsigned o) : m_ptr(p), m_bits(b), m_offset(o) {}
+
+  const_iterator(const const_iterator& rhs) : m_ptr(rhs.m_ptr), m_bits(rhs.m_bits), m_offset(rhs.m_offset) {}
+
+  template <unsigned BITS, bool TS>
+  const_iterator(const iterator<IDX, BITS, W, TS>& rhs)
+      : m_ptr(rhs.m_ptr), m_bits(rhs.m_bits), m_offset(rhs.m_offset) {}
+
+  const_iterator(std::nullptr_t) : m_ptr(nullptr), m_bits(0), m_offset(0) {}
+
+  unsigned bits() const {
+    return m_bits;
+  }
+
+  void bits(unsigned b) {
+    m_bits = b;
+  }
 };
 
-
 // No specialization. Static number of bits used.
-template<typename IDX, unsigned BITS, typename W, bool TS, unsigned UB>
-class iterator :
-    public iterator_imp::iterator_types<IDX>,
-    public iterator_imp::common<iterator<IDX, BITS, W, TS, UB>, IDX, BITS, W, UB>
-{
-  W*       m_ptr;
+template <typename IDX, unsigned BITS, typename W, bool TS, unsigned UB>
+class iterator : public iterator_imp::iterator_types<IDX>,
+                 public iterator_imp::common<iterator<IDX, BITS, W, TS, UB>, IDX, BITS, W, UB> {
+  W* m_ptr;
   unsigned m_offset;
 
   friend class iterator<IDX, BITS, W, !TS, UB>;
@@ -927,25 +967,29 @@ class iterator :
   friend class iterator_imp::common<const_iterator<IDX, BITS, W, UB>, IDX, BITS, W, UB>;
 
   typedef iterator_imp::iterator_types<IDX> super;
-public:
-  typedef typename super::value_type                  value_type;
-  typedef typename super::difference_type             difference_type;
-  typedef IDX                                         idx_type;
-  typedef W                                           word_type;
+
+ public:
+  typedef typename super::value_type value_type;
+  typedef typename super::difference_type difference_type;
+  typedef IDX idx_type;
+  typedef W word_type;
   typedef iterator_imp::lhs_setter<IDX, BITS, W, TS, UB> lhs_setter_type;
 
   iterator() = default;
-  iterator(W* p, unsigned o)
-    : m_ptr(p), m_offset(o) { }
-  iterator(W* p, unsigned b, unsigned o)
-    : m_ptr(p), m_offset(o) { } // XXX Should we assert that BITS == b?
-  template<bool TTS>
-  iterator(const iterator<IDX, BITS, W, TTS>& rhs)
-    : m_ptr(rhs.m_ptr), m_offset(rhs.m_offset) { }
-  iterator(std::nullptr_t)
-    : m_ptr(nullptr), m_offset(0) { }
 
-  lhs_setter_type operator*() { return lhs_setter_type(m_ptr, m_offset); }
+  iterator(W* p, unsigned o) : m_ptr(p), m_offset(o) {}
+
+  iterator(W* p, unsigned b, unsigned o) : m_ptr(p), m_offset(o) {}  // XXX Should we assert that BITS == b?
+
+  template <bool TTS>
+  iterator(const iterator<IDX, BITS, W, TTS>& rhs) : m_ptr(rhs.m_ptr), m_offset(rhs.m_offset) {}
+
+  iterator(std::nullptr_t) : m_ptr(nullptr), m_offset(0) {}
+
+  lhs_setter_type operator*() {
+    return lhs_setter_type(m_ptr, m_offset);
+  }
+
   lhs_setter_type operator[](const difference_type n) const {
     return *(*this + n);
   }
@@ -956,16 +1000,17 @@ public:
     return iterator_imp::gs<IDX, BITS, W, UB>::cas(x, exp, m_ptr, m_offset);
   }
 
-  constexpr unsigned bits() const { return BITS; }
-protected:
-  void bits(unsigned b) { } // NOOP
+  constexpr unsigned bits() const {
+    return BITS;
+  }
+
+ protected:
+  void bits(unsigned b) {}  // NOOP
 };
 
-template<typename IDX, unsigned BITS, typename W, unsigned UB>
-class const_iterator :
-  public iterator_imp::iterator_types<const IDX>,
-  public iterator_imp::common<const_iterator<IDX, BITS, W, UB>, IDX, BITS, W, UB>
-{
+template <typename IDX, unsigned BITS, typename W, unsigned UB>
+class const_iterator : public iterator_imp::iterator_types<const IDX>,
+                       public iterator_imp::common<const_iterator<IDX, BITS, W, UB>, IDX, BITS, W, UB> {
   const W* m_ptr;
   unsigned m_offset;
 
@@ -975,41 +1020,45 @@ class const_iterator :
   friend class iterator_imp::common<const_iterator<IDX, BITS, W, UB>, IDX, BITS, W, UB>;
 
   typedef iterator_imp::iterator_types<IDX> super;
-public:
-  typedef typename super::value_type      value_type;
+
+ public:
+  typedef typename super::value_type value_type;
   typedef typename super::difference_type difference_type;
   typedef IDX idx_type;
-  typedef W   word_type;
-
+  typedef W word_type;
 
   const_iterator() = default;
-  const_iterator(const W* p, unsigned o)
-    : m_ptr(p), m_offset(o) { }
-  const_iterator(const W* p, unsigned b, unsigned o)
-    : m_ptr(p), m_offset(o) { }
-  const_iterator(const const_iterator& rhs)
-    : m_ptr(rhs.m_ptr), m_offset(rhs.m_offset) { }
-  template<bool TS>
-  const_iterator(const iterator<IDX, BITS, W, TS>& rhs)
-    : m_ptr(rhs.m_ptr), m_offset(rhs.m_offset) { }
-  const_iterator(std::nullptr_t)
-    : m_ptr(nullptr), m_offset(0) { }
 
-  constexpr unsigned bits() const { return BITS; }
-protected:
-  void bits(unsigned b) { } // NOOP
+  const_iterator(const W* p, unsigned o) : m_ptr(p), m_offset(o) {}
+
+  const_iterator(const W* p, unsigned b, unsigned o) : m_ptr(p), m_offset(o) {}
+
+  const_iterator(const const_iterator& rhs) : m_ptr(rhs.m_ptr), m_offset(rhs.m_offset) {}
+
+  template <bool TS>
+  const_iterator(const iterator<IDX, BITS, W, TS>& rhs) : m_ptr(rhs.m_ptr), m_offset(rhs.m_offset) {}
+
+  const_iterator(std::nullptr_t) : m_ptr(nullptr), m_offset(0) {}
+
+  constexpr unsigned bits() const {
+    return BITS;
+  }
+
+ protected:
+  void bits(unsigned b) {}  // NOOP
 };
 
-template<typename I, unsigned BITS, typename W, bool TS, unsigned UB>
+template <typename I, unsigned BITS, typename W, bool TS, unsigned UB>
 struct const_iterator_traits<iterator<I, BITS, W, TS, UB>> {
   typedef const_iterator<I, BITS, W, UB> type;
 };
-template<typename I, unsigned BITS, typename W, unsigned UB>
+
+template <typename I, unsigned BITS, typename W, unsigned UB>
 struct const_iterator_traits<const_iterator<I, BITS, W, UB>> {
   typedef const_iterator<I, BITS, W, UB> type;
 };
 
-template<typename I, unsigned BITS, typename W, bool TS, unsigned UB>
+template <typename I, unsigned BITS, typename W, bool TS, unsigned UB>
 struct parallel_iterator_traits<iterator<I, BITS, W, TS, UB>> {
   typedef iterator<I, BITS, W, true, UB> type;
 
@@ -1020,29 +1069,37 @@ struct parallel_iterator_traits<iterator<I, BITS, W, TS, UB>> {
   }
 };
 
-template<typename I, unsigned BITS, typename W, unsigned UB>
+template <typename I, unsigned BITS, typename W, unsigned UB>
 struct parallel_iterator_traits<const_iterator<I, BITS, W, UB>> {
   typedef const_iterator<I, BITS, W> type;
 };
 
-template<typename I, unsigned BITS, typename W, bool TS, unsigned UB>
-struct prefetch_iterator_traits<iterator<I, BITS, W, TS, UB> > {
-  template<int level = 0>
-  static void read(const iterator<I, BITS, W, TS, UB>& p) { prefetch_iterator_traits<W*>::template read<level>(p.get_ptr()); }
-  template<int level = 0>
-  static void write(const iterator<I, BITS, W, TS, UB>& p) { prefetch_iterator_traits<W*>::template write<level>(p.get_ptr()); }
+template <typename I, unsigned BITS, typename W, bool TS, unsigned UB>
+struct prefetch_iterator_traits<iterator<I, BITS, W, TS, UB>> {
+  template <int level = 0>
+  static void read(const iterator<I, BITS, W, TS, UB>& p) {
+    prefetch_iterator_traits<W*>::template read<level>(p.get_ptr());
+  }
 
+  template <int level = 0>
+  static void write(const iterator<I, BITS, W, TS, UB>& p) {
+    prefetch_iterator_traits<W*>::template write<level>(p.get_ptr());
+  }
 };
 
-template<typename I, unsigned BITS, typename W, unsigned UB>
-struct prefetch_iterator_traits<const_iterator<I, BITS, W, UB> > {
-  template<int level = 0>
-  static void read(const const_iterator<I, BITS, W, UB>& p) { prefetch_iterator_traits<const W*>::template read<level>(p.get_ptr()); }
-  template<int level = 0>
-  static void write(const const_iterator<I, BITS, W, UB>& p) { prefetch_iterator_traits<const W*>::template write<level>(p.get_ptr()); }
+template <typename I, unsigned BITS, typename W, unsigned UB>
+struct prefetch_iterator_traits<const_iterator<I, BITS, W, UB>> {
+  template <int level = 0>
+  static void read(const const_iterator<I, BITS, W, UB>& p) {
+    prefetch_iterator_traits<const W*>::template read<level>(p.get_ptr());
+  }
 
+  template <int level = 0>
+  static void write(const const_iterator<I, BITS, W, UB>& p) {
+    prefetch_iterator_traits<const W*>::template write<level>(p.get_ptr());
+  }
 };
 
-} // namespace compact
+}  // namespace compact
 
 #endif /* __COMPACT_ITERATOR_H__ */

--- a/include/compact_vector.hpp
+++ b/include/compact_vector.hpp
@@ -1,30 +1,36 @@
 #ifndef __COMPACT_VECTOR_H__
 #define __COMPACT_VECTOR_H__
 
+#include <algorithm>
+#include <cstring>
 #include <new>
 #include <stdexcept>
-#include <cstring>
-#include <algorithm>
-#include <memory>
 
 #include "compact_iterator.hpp"
 
 namespace compact {
 
 namespace vector_imp {
-inline int clz(unsigned int x) { return __builtin_clz(x); }
-inline int clz(unsigned long x) { return __builtin_clzl(x); }
-inline int clz(unsigned long long x) { return __builtin_clzll(x); }
+inline int clz(unsigned int x) {
+  return __builtin_clz(x);
+}
 
-template<class Derived,
-         typename IDX, unsigned BITS, typename W, typename Allocator, unsigned UB, bool TS>
+inline int clz(unsigned long x) {
+  return __builtin_clzl(x);
+}
+
+inline int clz(unsigned long long x) {
+  return __builtin_clzll(x);
+}
+
+template <class Derived, typename IDX, unsigned BITS, typename W, typename Allocator, unsigned UB, bool TS>
 class vector {
-  Allocator                                           m_allocator;
-  size_t                                              m_size;             // Size in number of elements
-  size_t                                              m_capacity;         // Capacity in number of elements
-  typename std::allocator_traits<Allocator>::pointer  m_mem;
+  Allocator m_allocator;
+  size_t m_size;      // Size in number of elements
+  size_t m_capacity;  // Capacity in number of elements
+  typename std::allocator_traits<Allocator>::pointer m_mem;
 
-public:
+ public:
   // Number of bits required for indices/values in the range [0, s).
   static unsigned required_bits(size_t s) {
     unsigned res = bitsof<size_t>::val - 1 - clz(s);
@@ -37,18 +43,18 @@ public:
     return total_bits / UB + (total_bits % UB != 0);
   }
 
-  typedef compact::iterator<IDX, BITS, W, TS, UB>   iterator;
+  typedef compact::iterator<IDX, BITS, W, TS, UB> iterator;
   typedef compact::const_iterator<IDX, BITS, W, UB> const_iterator;
-  typedef compact::iterator<IDX, BITS, W, true, UB> mt_iterator; // Multi thread safe version
-  typedef std::reverse_iterator<iterator>        reverse_iterator;
-  typedef std::reverse_iterator<const_iterator>  const_reverse_iterator;
+  typedef compact::iterator<IDX, BITS, W, true, UB> mt_iterator;  // Multi thread safe version
+  typedef std::reverse_iterator<iterator> reverse_iterator;
+  typedef std::reverse_iterator<const_iterator> const_reverse_iterator;
   typedef typename std::allocator_traits<Allocator>::pointer pointer;
 
-protected:
+ protected:
   static pointer allocate_s(size_t capacity, unsigned bits, Allocator& allocator) {
     const auto nb_words = elements_to_words(capacity, bits);
     pointer res = std::allocator_traits<Allocator>::allocate(allocator, nb_words);
-    if(UB != bitsof<W>::val) // CAS vector, expect high bit of each word to be zero, so zero it all
+    if (UB != bitsof<W>::val)  // CAS vector, expect high bit of each word to be zero, so zero it all
       std::fill_n(res, nb_words, (W)0);
     return res;
   }
@@ -64,167 +70,237 @@ protected:
   // Error messages
   static constexpr const char* EOUTOFRANGE = "Index is out of range";
 
-public:
-
-  vector(vector &&rhs)
-    : m_allocator(std::move(rhs.m_allocator))
-    , m_size(rhs.m_size)
-    , m_capacity(rhs.m_capacity)
-    , m_mem(rhs.m_mem)
-  {
+ public:
+  vector(vector&& rhs)
+      : m_allocator(std::move(rhs.m_allocator)), m_size(rhs.m_size), m_capacity(rhs.m_capacity), m_mem(rhs.m_mem) {
     rhs.m_size = rhs.m_capacity = 0;
     rhs.m_mem = nullptr;
   }
-  vector(const vector &rhs)
-    : m_allocator(rhs.m_allocator)
-    , m_size(rhs.m_size)
-    , m_capacity(rhs.m_capacity)
-    , m_mem(allocate_s(m_capacity, rhs.bits(), m_allocator))
-  {
+
+  vector(const vector& rhs)
+      : m_allocator(rhs.m_allocator),
+        m_size(rhs.m_size),
+        m_capacity(rhs.m_capacity),
+        m_mem(allocate_s(m_capacity, rhs.bits(), m_allocator)) {
     std::memcpy(m_mem, rhs.m_mem, rhs.bytes());
   }
 
   vector(unsigned b, size_t s, Allocator allocator = Allocator())
-    : m_allocator(allocator)
-    , m_size(s)
-    , m_capacity(s)
-    , m_mem(allocate_s(s, b, m_allocator))
-  {
+      : m_allocator(allocator), m_size(s), m_capacity(s), m_mem(allocate_s(s, b, m_allocator)) {
     static_assert(UB <= bitsof<W>::val, "used_bits must be less or equal to the number of bits in the word_type");
     static_assert(BITS <= UB, "number of bits larger than usable bits");
   }
-  explicit vector(Allocator allocator = Allocator())
-    : vector(0, 0, allocator)
-  { }
+
+  explicit vector(Allocator allocator = Allocator()) : vector(0, 0, allocator) {}
+
   ~vector() {
     std::allocator_traits<Allocator>::deallocate(m_allocator, m_mem, elements_to_words(m_capacity, bits()));
   }
 
   vector& operator=(const vector& rhs) {
     m_allocator = rhs.m_allocator;
-    if(m_capacity < rhs.size()) {
+    if (m_capacity < rhs.size()) {
       deallocate(m_mem, m_capacity);
       m_capacity = rhs.size();
       m_mem = allocate(m_capacity);
     }
-    m_size      = rhs.m_size;
+    m_size = rhs.m_size;
     std::memcpy(m_mem, rhs.m_mem, bytes());
     return *this;
   }
 
   vector& operator=(vector&& rhs) {
     m_allocator = std::move(rhs.m_allocator);
-    m_size      = rhs.m_size;
-    m_capacity  = rhs.m_capacity;
-    m_mem       = rhs.m_mem;
+    m_size = rhs.m_size;
+    m_capacity = rhs.m_capacity;
+    m_mem = rhs.m_mem;
 
     rhs.m_size = rhs.m_capacity = 0;
-    rhs.m_mem  = nullptr;
+    rhs.m_mem = nullptr;
     return *this;
   }
 
-  const_iterator begin() const { return const_iterator(m_mem, bits(), 0); }
-  iterator begin() { return iterator(m_mem, bits(), 0); }
-  const_iterator end() const { return begin() + m_size; }
-  iterator end() { return begin() + m_size; }
-  const_iterator cbegin() const { return begin(); }
-  const_iterator cend() const { return end(); }
-  const_reverse_iterator rbegin() const { return const_reverse_iterator(end()); }
-  reverse_iterator rbegin() { return reverse_iterator(end()); }
-  const_reverse_iterator rend() const { return const_reverse_iterator(begin()); }
-  reverse_iterator rend() { return reverse_iterator(begin()); }
-  const_reverse_iterator crbegin() const { return const_reverse_iterator(end()); }
-  const_reverse_iterator crend() const { return const_reverse_iterator(begin()); }
+  const_iterator begin() const {
+    const W* raw_mem = std::to_address(m_mem);
+    return const_iterator(raw_mem, bits(), 0);
+  }
+
+  iterator begin() {
+    W* raw_mem = std::to_address(m_mem);
+    return iterator(raw_mem, bits(), 0);
+  }
+
+  const_iterator end() const {
+    return begin() + m_size;
+  }
+
+  iterator end() {
+    return begin() + m_size;
+  }
+
+  const_iterator cbegin() const {
+    return begin();
+  }
+
+  const_iterator cend() const {
+    return end();
+  }
+
+  const_reverse_iterator rbegin() const {
+    return const_reverse_iterator(end());
+  }
+
+  reverse_iterator rbegin() {
+    return reverse_iterator(end());
+  }
+
+  const_reverse_iterator rend() const {
+    return const_reverse_iterator(begin());
+  }
+
+  reverse_iterator rend() {
+    return reverse_iterator(begin());
+  }
+
+  const_reverse_iterator crbegin() const {
+    return const_reverse_iterator(end());
+  }
+
+  const_reverse_iterator crend() const {
+    return const_reverse_iterator(begin());
+  }
 
   // Multi thread safe iterator
-  mt_iterator mt_begin() { return mt_iterator(m_mem, bits(), 0); }
-  mt_iterator mt_end() { return begin() + m_size; }
+  mt_iterator mt_begin() {
+    return mt_iterator(m_mem, bits(), 0);
+  }
+
+  mt_iterator mt_end() {
+    return begin() + m_size;
+  }
 
   IDX operator[](size_t i) const {
-    return BITS
-      ? *const_iterator(m_mem + (i * BITS) / UB, BITS, (i * BITS) % UB)
-      : *const_iterator(m_mem + (i * bits()) / UB, bits(), (i * bits()) % UB);
+    const W* raw_mem = std::to_address(m_mem);
+    return BITS ? *const_iterator(raw_mem + (i * BITS) / UB, BITS, (i * BITS) % UB)
+                : *const_iterator(raw_mem + (i * bits()) / UB, bits(), (i * bits()) % UB);
     // return cbegin()[i];
   }
+
   IDX at(size_t i) const {
-    if(i >= size()) throw std::out_of_range(EOUTOFRANGE);
+    if (i >= size())
+      throw std::out_of_range(EOUTOFRANGE);
     return this->operator[](i);
   }
+
   typename iterator::lhs_setter_type operator[](size_t i) {
-    return BITS
-      ? typename iterator::lhs_setter_type(m_mem + (i * BITS) / UB, BITS, (i * BITS) % UB)
-      : typename iterator::lhs_setter_type(m_mem + (i * bits()) / UB, bits(), (i * bits()) % UB);
+    const W* raw_mem = std::to_address(m_mem);
+    return BITS ? typename iterator::lhs_setter_type(raw_mem + (i * BITS) / UB, BITS, (i * BITS) % UB)
+                : typename iterator::lhs_setter_type(raw_mem + (i * bits()) / UB, bits(), (i * bits()) % UB);
     //  return begin()[i];
   }
+
   typename iterator::lhs_setter_type at(size_t i) {
-    if(i >= size()) throw std::out_of_range(EOUTOFRANGE);
+    if (i >= size())
+      throw std::out_of_range(EOUTOFRANGE);
     return this->operator[](i);
   }
 
   template <class InputIterator>
-  void assign (InputIterator first, InputIterator last) {
+  void assign(InputIterator first, InputIterator last) {
     clear();
-    for( ; first != last; ++first)
+    for (; first != last; ++first)
       push_back(*first);
   }
-  void assign (size_t n, const IDX& val) {
+
+  void assign(size_t n, const IDX& val) {
     clear();
-    for(size_t i = 0; i < n; ++i)
+    for (size_t i = 0; i < n; ++i)
       push_back(val);
   }
-  inline void assign (std::initializer_list<IDX> il) {
+
+  inline void assign(std::initializer_list<IDX> il) {
     assign(il.begin(), il.end());
   }
 
-  void resize (size_t n, const IDX& val) {
-    if(n <= size()) {
+  void resize(size_t n, const IDX& val) {
+    if (n <= size()) {
       m_size = n;
       return;
     }
-    if(n > m_capacity)
+    if (n > m_capacity)
       enlarge(n);
 
     auto it = begin() + size();
-    for(size_t i = size(); i < n; ++i, ++it)
+    for (size_t i = size(); i < n; ++i, ++it)
       *it = val;
     m_size = n;
   }
-  inline void resize (size_t n) { resize(n, IDX()); }
 
-  inline iterator erase (const_iterator position) { return erase(position, position + 1); }
-  iterator erase (const_iterator first, const_iterator last) {
+  inline void resize(size_t n) {
+    resize(n, IDX());
+  }
+
+  inline iterator erase(const_iterator position) {
+    return erase(position, position + 1);
+  }
+
+  iterator erase(const_iterator first, const_iterator last) {
     const auto length = last - first;
     iterator res(begin() + (first - cbegin()));
-    if(length) {
+    if (length) {
       std::copy(last, cend(), res);
       m_size -= length;
     }
     return res;
   }
 
+  IDX front() const {
+    return *cbegin();
+  }
 
-  IDX front() const { return *cbegin(); }
-  typename iterator::lhs_setter_type front() { return *begin(); }
-  IDX back() const { return *(cbegin() + (m_size - 1)); }
-  typename iterator::lhs_setter_type back() { return *(begin() + (m_size - 1)); }
+  typename iterator::lhs_setter_type front() {
+    return *begin();
+  }
 
-  size_t size() const { return m_size; }
-  bool empty() const { return m_size == 0; }
-  size_t capacity() const { return m_capacity; }
+  IDX back() const {
+    return *(cbegin() + (m_size - 1));
+  }
+
+  typename iterator::lhs_setter_type back() {
+    return *(begin() + (m_size - 1));
+  }
+
+  size_t size() const {
+    return m_size;
+  }
+
+  bool empty() const {
+    return m_size == 0;
+  }
+
+  size_t capacity() const {
+    return m_capacity;
+  }
 
   void push_back(IDX x) {
-    if(m_size == m_capacity)
+    if (m_size == m_capacity)
       enlarge();
     *end() = x;
     ++m_size;
   }
 
-  void pop_back() { --m_size; }
-  void clear() { m_size = 0; }
-  iterator emplace (const_iterator position, IDX x) {
+  void pop_back() {
+    --m_size;
+  }
+
+  void clear() {
+    m_size = 0;
+  }
+
+  iterator emplace(const_iterator position, IDX x) {
     const ssize_t osize = size();
     const ssize_t distance = position - begin();
-    if(distance == osize) {
+    if (distance == osize) {
       push_back(x);
       return begin() + distance;
     }
@@ -234,275 +310,268 @@ public:
     *res = x;
     return res;
   }
-  void emplace_back(IDX x) { push_back(x); }
 
-  pointer get() { return m_mem; }
-  const pointer get() const { return m_mem; }
-  size_t bytes() const { return sizeof(W) * elements_to_words(m_capacity, bits()); }
-  inline unsigned bits() const { return static_cast<const Derived*>(this)->bits(); }
-  static constexpr unsigned static_bits() { return BITS; }
-  static constexpr unsigned used_bits() { return UB; }
-  static constexpr bool thread_safe() { return TS; }
+  void emplace_back(IDX x) {
+    push_back(x);
+  }
 
-protected:
+  pointer get() {
+    return m_mem;
+  }
+
+  const pointer get() const {
+    return m_mem;
+  }
+
+  size_t bytes() const {
+    return sizeof(W) * elements_to_words(m_capacity, bits());
+  }
+
+  inline unsigned bits() const {
+    return static_cast<const Derived*>(this)->bits();
+  }
+
+  static constexpr unsigned static_bits() {
+    return BITS;
+  }
+
+  static constexpr unsigned used_bits() {
+    return UB;
+  }
+
+  static constexpr bool thread_safe() {
+    return TS;
+  }
+
+ protected:
   void enlarge(size_t given = 0) {
     const size_t new_capacity = !given ? std::max(m_capacity * 2, (size_t)(bitsof<W>::val / bits() + 1)) : given;
     pointer new_mem = allocate(new_capacity);
     std::copy(m_mem, m_mem + elements_to_words(m_capacity, bits()), new_mem);
     deallocate(m_mem, m_capacity);
-    m_mem      = new_mem;
+    m_mem = new_mem;
     m_capacity = new_capacity;
   }
 };
 
-template<typename IDX, typename W, typename Allocator, unsigned UB, bool TS>
-class vector_dyn
-  : public vector_imp::vector<vector_dyn<IDX, W, Allocator, UB, TS>, IDX, 0, W, Allocator, UB, TS>
-{
+template <typename IDX, typename W, typename Allocator, unsigned UB, bool TS>
+class vector_dyn : public vector_imp::vector<vector_dyn<IDX, W, Allocator, UB, TS>, IDX, 0, W, Allocator, UB, TS> {
   typedef vector_imp::vector<vector_dyn<IDX, W, Allocator, UB, TS>, IDX, 0, W, Allocator, UB, TS> super;
-  const unsigned m_bits;    // Number of bits in an element
+  const unsigned m_bits;  // Number of bits in an element
 
-public:
-  typedef typename super::iterator              iterator;
-  typedef typename super::const_iterator        const_iterator;
-  typedef IDX                                   value_type;
-  typedef Allocator                             allocator_type;
-  typedef typename iterator::lhs_setter_type    reference;
-  typedef const reference                       const_reference;
-  typedef iterator                              pointer;
-  typedef const_iterator                        const_pointer;
-  typedef std::reverse_iterator<iterator>       reverse_iterator;
+ public:
+  typedef typename super::iterator iterator;
+  typedef typename super::const_iterator const_iterator;
+  typedef IDX value_type;
+  typedef Allocator allocator_type;
+  typedef typename iterator::lhs_setter_type reference;
+  typedef const reference const_reference;
+  typedef iterator pointer;
+  typedef const_iterator const_pointer;
+  typedef std::reverse_iterator<iterator> reverse_iterator;
   typedef std::reverse_iterator<const_iterator> const_reverse_iterator;
-  typedef ptrdiff_t                             difference_type;
-  typedef size_t                                size_type;
-  typedef W                                     word_type;
+  typedef ptrdiff_t difference_type;
+  typedef size_t size_type;
+  typedef W word_type;
 
-  vector_dyn(unsigned b, size_t s, Allocator allocator = Allocator())
-    : super(b, s, allocator)
-    , m_bits(b)
-  { }
-  vector_dyn(unsigned b, Allocator allocator = Allocator())
-    : super(allocator)
-    , m_bits(b)
-  { }
+  vector_dyn(unsigned b, size_t s, Allocator allocator = Allocator()) : super(b, s, allocator), m_bits(b) {}
 
-  vector_dyn(vector_dyn&& rhs)
-    : super(std::move(rhs))
-    , m_bits(rhs.bits())
-  { }
+  vector_dyn(unsigned b, Allocator allocator = Allocator()) : super(allocator), m_bits(b) {}
 
-  vector_dyn(const vector_dyn& rhs)
-    : super(rhs)
-    , m_bits(rhs.bits())
-  { }
+  vector_dyn(vector_dyn&& rhs) : super(std::move(rhs)), m_bits(rhs.bits()) {}
 
-  inline unsigned bits() const { return m_bits; }
+  vector_dyn(const vector_dyn& rhs) : super(rhs), m_bits(rhs.bits()) {}
+
+  inline unsigned bits() const {
+    return m_bits;
+  }
 
   vector_dyn& operator=(const vector_dyn& rhs) {
-    if(bits() != rhs.bits())
+    if (bits() != rhs.bits())
       throw std::invalid_argument("Bit length of compacted vector differ");
     static_cast<super*>(this)->operator=(rhs);
     return *this;
   }
 
   vector_dyn& operator=(vector_dyn&& rhs) {
-    if(bits() != rhs.bits())
+    if (bits() != rhs.bits())
       throw std::invalid_argument("Bit length of compacted vector differ");
     static_cast<super*>(this)->operator=(std::move(rhs));
     return *this;
   }
 };
 
-} // namespace vector_imp
+}  // namespace vector_imp
 
-template<typename IDX, unsigned BITS = 0, typename W = uint64_t, typename Allocator = std::allocator<W>>
+template <typename IDX, unsigned BITS = 0, typename W = uint64_t, typename Allocator = std::allocator<W>>
 class vector
-  : public vector_imp::vector<vector<IDX, BITS, W, Allocator>, IDX, BITS, W, Allocator, bitsof<W>::val, false>
-{
+    : public vector_imp::vector<vector<IDX, BITS, W, Allocator>, IDX, BITS, W, Allocator, bitsof<W>::val, false> {
   typedef vector_imp::vector<vector<IDX, BITS, W, Allocator>, IDX, BITS, W, Allocator, bitsof<W>::val, false> super;
 
-public:
-  typedef typename super::iterator              iterator;
-  typedef typename super::const_iterator        const_iterator;
-  typedef IDX                                   value_type;
-  typedef Allocator                             allocator_type;
-  typedef typename iterator::lhs_setter_type    reference;
-  typedef const reference                       const_reference;
-  typedef iterator                              pointer;
-  typedef const_iterator                        const_pointer;
-  typedef std::reverse_iterator<iterator>       reverse_iterator;
+ public:
+  typedef typename super::iterator iterator;
+  typedef typename super::const_iterator const_iterator;
+  typedef IDX value_type;
+  typedef Allocator allocator_type;
+  typedef typename iterator::lhs_setter_type reference;
+  typedef const reference const_reference;
+  typedef iterator pointer;
+  typedef const_iterator const_pointer;
+  typedef std::reverse_iterator<iterator> reverse_iterator;
   typedef std::reverse_iterator<const_iterator> const_reverse_iterator;
-  typedef ptrdiff_t                             difference_type;
-  typedef size_t                                size_type;
-  typedef W                                     word_type;
+  typedef ptrdiff_t difference_type;
+  typedef size_t size_type;
+  typedef W word_type;
 
-  vector(size_t s, Allocator allocator = Allocator())
-    : super(BITS, s, allocator)
-  { }
-  vector(Allocator allocator = Allocator())
-    : super(allocator)
-  { }
+  vector(size_t s, Allocator allocator = Allocator()) : super(BITS, s, allocator) {}
 
-  static constexpr unsigned bits() { return BITS; }
+  vector(Allocator allocator = Allocator()) : super(allocator) {}
+
+  static constexpr unsigned bits() {
+    return BITS;
+  }
 };
 
-template<typename IDX, typename W, typename Allocator>
-class vector<IDX, 0, W, Allocator>
-  : public vector_imp::vector_dyn<IDX, W, Allocator, bitsof<W>::val, false>
-{
+template <typename IDX, typename W, typename Allocator>
+class vector<IDX, 0, W, Allocator> : public vector_imp::vector_dyn<IDX, W, Allocator, bitsof<W>::val, false> {
   typedef vector_imp::vector_dyn<IDX, W, Allocator, bitsof<W>::val, false> super;
 
-public:
-  typedef typename super::iterator              iterator;
-  typedef typename super::const_iterator        const_iterator;
-  typedef IDX                                   value_type;
-  typedef Allocator                             allocator_type;
-  typedef typename iterator::lhs_setter_type    reference;
-  typedef const reference                       const_reference;
-  typedef iterator                              pointer;
-  typedef const_iterator                        const_pointer;
-  typedef std::reverse_iterator<iterator>       reverse_iterator;
+ public:
+  typedef typename super::iterator iterator;
+  typedef typename super::const_iterator const_iterator;
+  typedef IDX value_type;
+  typedef Allocator allocator_type;
+  typedef typename iterator::lhs_setter_type reference;
+  typedef const reference const_reference;
+  typedef iterator pointer;
+  typedef const_iterator const_pointer;
+  typedef std::reverse_iterator<iterator> reverse_iterator;
   typedef std::reverse_iterator<const_iterator> const_reverse_iterator;
-  typedef ptrdiff_t                             difference_type;
-  typedef size_t                                size_type;
-  typedef W                                     word_type;
+  typedef ptrdiff_t difference_type;
+  typedef size_t size_type;
+  typedef W word_type;
 
-  vector(unsigned b, size_t s, Allocator allocator = Allocator())
-    : super(b, s, allocator)
-  {
-    if(b > bitsof<W>::val)
+  vector(unsigned b, size_t s, Allocator allocator = Allocator()) : super(b, s, allocator) {
+    if (b > bitsof<W>::val)
       throw std::out_of_range("Number of bits larger than usable bits");
   }
-  vector(unsigned b, Allocator allocator = Allocator())
-    : super(b, allocator)
-  { }
+
+  vector(unsigned b, Allocator allocator = Allocator()) : super(b, allocator) {}
 };
 
-template<typename IDX, unsigned BITS = 0, typename W = uint64_t, typename Allocator = std::allocator<W>>
+template <typename IDX, unsigned BITS = 0, typename W = uint64_t, typename Allocator = std::allocator<W>>
 class ts_vector
-  : public vector_imp::vector<ts_vector<IDX, BITS, W, Allocator>, IDX, BITS, W, Allocator, bitsof<W>::val, true>
-{
+    : public vector_imp::vector<ts_vector<IDX, BITS, W, Allocator>, IDX, BITS, W, Allocator, bitsof<W>::val, true> {
   typedef vector_imp::vector<ts_vector<IDX, BITS, W, Allocator>, IDX, BITS, W, Allocator, bitsof<W>::val, true> super;
 
-public:
-  typedef typename super::iterator              iterator;
-  typedef typename super::const_iterator        const_iterator;
-  typedef IDX                                   value_type;
-  typedef Allocator                             allocator_type;
-  typedef typename iterator::lhs_setter_type    reference;
-  typedef const reference                       const_reference;
-  typedef iterator                              pointer;
-  typedef const_iterator                        const_pointer;
-  typedef std::reverse_iterator<iterator>       reverse_iterator;
+ public:
+  typedef typename super::iterator iterator;
+  typedef typename super::const_iterator const_iterator;
+  typedef IDX value_type;
+  typedef Allocator allocator_type;
+  typedef typename iterator::lhs_setter_type reference;
+  typedef const reference const_reference;
+  typedef iterator pointer;
+  typedef const_iterator const_pointer;
+  typedef std::reverse_iterator<iterator> reverse_iterator;
   typedef std::reverse_iterator<const_iterator> const_reverse_iterator;
-  typedef ptrdiff_t                             difference_type;
-  typedef size_t                                size_type;
-  typedef W                                     word_type;
+  typedef ptrdiff_t difference_type;
+  typedef size_t size_type;
+  typedef W word_type;
 
-  ts_vector(size_t s, Allocator allocator = Allocator())
-    : super(BITS, s, allocator)
-  { }
-  ts_vector(Allocator allocator = Allocator())
-    : super(allocator)
-  { }
+  ts_vector(size_t s, Allocator allocator = Allocator()) : super(BITS, s, allocator) {}
 
-  static constexpr unsigned bits() { return BITS; }
+  ts_vector(Allocator allocator = Allocator()) : super(allocator) {}
+
+  static constexpr unsigned bits() {
+    return BITS;
+  }
 };
 
-
-template<typename IDX, typename W, typename Allocator>
-class ts_vector<IDX, 0, W, Allocator>
-  : public vector_imp::vector_dyn<IDX, W, Allocator, bitsof<W>::val, true>
-{
+template <typename IDX, typename W, typename Allocator>
+class ts_vector<IDX, 0, W, Allocator> : public vector_imp::vector_dyn<IDX, W, Allocator, bitsof<W>::val, true> {
   typedef vector_imp::vector_dyn<IDX, W, Allocator, bitsof<W>::val, true> super;
-public:
-  typedef typename super::iterator              iterator;
-  typedef typename super::const_iterator        const_iterator;
-  typedef IDX                                   value_type;
-  typedef Allocator                             allocator_type;
-  typedef typename iterator::lhs_setter_type    reference;
-  typedef const reference                       const_reference;
-  typedef iterator                              pointer;
-  typedef const_iterator                        const_pointer;
-  typedef std::reverse_iterator<iterator>       reverse_iterator;
-  typedef std::reverse_iterator<const_iterator> const_reverse_iterator;
-  typedef ptrdiff_t                             difference_type;
-  typedef size_t                                size_type;
-  typedef W                                     word_type;
 
-  ts_vector(unsigned b, size_t s, Allocator allocator = Allocator())
-    : super(b, s, allocator)
-  {
-    if(b > bitsof<W>::val)
+ public:
+  typedef typename super::iterator iterator;
+  typedef typename super::const_iterator const_iterator;
+  typedef IDX value_type;
+  typedef Allocator allocator_type;
+  typedef typename iterator::lhs_setter_type reference;
+  typedef const reference const_reference;
+  typedef iterator pointer;
+  typedef const_iterator const_pointer;
+  typedef std::reverse_iterator<iterator> reverse_iterator;
+  typedef std::reverse_iterator<const_iterator> const_reverse_iterator;
+  typedef ptrdiff_t difference_type;
+  typedef size_t size_type;
+  typedef W word_type;
+
+  ts_vector(unsigned b, size_t s, Allocator allocator = Allocator()) : super(b, s, allocator) {
+    if (b > bitsof<W>::val)
       throw std::out_of_range("Number of bits larger than usable bits");
   }
-  ts_vector(unsigned b, Allocator allocator = Allocator())
-    : super(b, allocator)
-  { }
+
+  ts_vector(unsigned b, Allocator allocator = Allocator()) : super(b, allocator) {}
 };
 
-template<typename IDX, unsigned BITS = 0, typename W = uint64_t, typename Allocator = std::allocator<W>>
-class cas_vector
-  : public vector_imp::vector<cas_vector<IDX, BITS, W, Allocator>, IDX, BITS, W, Allocator, bitsof<W>::val-1, true>
-{
-  typedef vector_imp::vector<cas_vector<IDX, BITS, W, Allocator>, IDX, BITS, W, Allocator, bitsof<W>::val-1, true> super;
+template <typename IDX, unsigned BITS = 0, typename W = uint64_t, typename Allocator = std::allocator<W>>
+class cas_vector : public vector_imp::vector<cas_vector<IDX, BITS, W, Allocator>, IDX, BITS, W, Allocator,
+                                             bitsof<W>::val - 1, true> {
+  typedef vector_imp::vector<cas_vector<IDX, BITS, W, Allocator>, IDX, BITS, W, Allocator, bitsof<W>::val - 1, true>
+      super;
 
-public:
-  typedef typename super::iterator              iterator;
-  typedef typename super::const_iterator        const_iterator;
-  typedef IDX                                   value_type;
-  typedef Allocator                             allocator_type;
-  typedef typename iterator::lhs_setter_type    reference;
-  typedef const reference                       const_reference;
-  typedef iterator                              pointer;
-  typedef const_iterator                        const_pointer;
-  typedef std::reverse_iterator<iterator>       reverse_iterator;
+ public:
+  typedef typename super::iterator iterator;
+  typedef typename super::const_iterator const_iterator;
+  typedef IDX value_type;
+  typedef Allocator allocator_type;
+  typedef typename iterator::lhs_setter_type reference;
+  typedef const reference const_reference;
+  typedef iterator pointer;
+  typedef const_iterator const_pointer;
+  typedef std::reverse_iterator<iterator> reverse_iterator;
   typedef std::reverse_iterator<const_iterator> const_reverse_iterator;
-  typedef ptrdiff_t                             difference_type;
-  typedef size_t                                size_type;
-  typedef W                                     word_type;
+  typedef ptrdiff_t difference_type;
+  typedef size_t size_type;
+  typedef W word_type;
 
-  cas_vector(size_t s, Allocator allocator = Allocator())
-    : super(BITS, s, allocator)
-  { }
-  cas_vector(Allocator allocator = Allocator())
-    : super(allocator)
-  { }
+  cas_vector(size_t s, Allocator allocator = Allocator()) : super(BITS, s, allocator) {}
 
-  static constexpr unsigned bits() { return BITS; }
+  cas_vector(Allocator allocator = Allocator()) : super(allocator) {}
+
+  static constexpr unsigned bits() {
+    return BITS;
+  }
 };
 
-template<typename IDX, typename W, typename Allocator>
-class cas_vector<IDX, 0, W, Allocator>
-  : public vector_imp::vector_dyn<IDX, W, Allocator, bitsof<W>::val - 1, true>
-{
+template <typename IDX, typename W, typename Allocator>
+class cas_vector<IDX, 0, W, Allocator> : public vector_imp::vector_dyn<IDX, W, Allocator, bitsof<W>::val - 1, true> {
   typedef vector_imp::vector_dyn<IDX, W, Allocator, bitsof<W>::val - 1, true> super;
-public:
-  typedef typename super::iterator              iterator;
-  typedef typename super::const_iterator        const_iterator;
-  typedef IDX                                   value_type;
-  typedef Allocator                             allocator_type;
-  typedef typename iterator::lhs_setter_type    reference;
-  typedef const reference                       const_reference;
-  typedef iterator                              pointer;
-  typedef const_iterator                        const_pointer;
-  typedef std::reverse_iterator<iterator>       reverse_iterator;
-  typedef std::reverse_iterator<const_iterator> const_reverse_iterator;
-  typedef ptrdiff_t                             difference_type;
-  typedef size_t                                size_type;
-  typedef W                                     word_type;
 
-  cas_vector(unsigned b, size_t s, Allocator allocator = Allocator())
-    : super(b, s, allocator)
-  {
-    if(b > bitsof<W>::val - 1)
+ public:
+  typedef typename super::iterator iterator;
+  typedef typename super::const_iterator const_iterator;
+  typedef IDX value_type;
+  typedef Allocator allocator_type;
+  typedef typename iterator::lhs_setter_type reference;
+  typedef const reference const_reference;
+  typedef iterator pointer;
+  typedef const_iterator const_pointer;
+  typedef std::reverse_iterator<iterator> reverse_iterator;
+  typedef std::reverse_iterator<const_iterator> const_reverse_iterator;
+  typedef ptrdiff_t difference_type;
+  typedef size_t size_type;
+  typedef W word_type;
+
+  cas_vector(unsigned b, size_t s, Allocator allocator = Allocator()) : super(b, s, allocator) {
+    if (b > bitsof<W>::val - 1)
       throw std::out_of_range("Number of bits larger than usable bits");
   }
-  cas_vector(unsigned b, Allocator allocator = Allocator())
-    : super(b, allocator)
-  { }
+
+  cas_vector(unsigned b, Allocator allocator = Allocator()) : super(b, allocator) {}
 };
 
-} // namespace compact
+}  // namespace compact
 
 #endif /* __COMPACT_VECTOR_H__ */


### PR DESCRIPTION
I'd like to use the compact vector with a custom allocator. My allocator uses a custom pointer type instead of `W*`.  In my change, I replace the hardcoded pointers with `std::allocator_traits<Allocator>::pointer`. Let me know, if there is additional changes required before merging. The tests suite exits successfully in my fork. 