### PR TITLE
Fix GCC 12 compilation error

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -23,36 +23,9 @@ jobs:
     - name: Install gtest
       run: |
         sudo apt-get update
-        sudo apt-get install libgtest-dev
         sudo apt-get install g++-12
+        sudo apt-get install libgtest-dev
     - name: configure ${{ matrix.standard }}
       run: autoreconf -fi && ./configure CXX=${{ matrix.compiler }} CXXFLAGS="-std=${{ matrix.standard }} -Wall -Werror"
-    - name: check ${{ matrix.standard }}
-      run: make -j 2 check
-
-  test_libcxx:
-    name: Unit tests with clang and libc++
-    runs-on: ubuntu-20.04
-    strategy:
-      matrix:
-        standard: [c++11, c++14, c++17, c++20]
-
-    steps:
-    - uses: actions/checkout@v3
-    - name: Install gtest
-      run: |
-        set -e
-        sudo apt install libc++-12-dev libc++1-12 libc++abi1-12 libc++abi-12-dev
-        mkdir gtest build
-        curl -L https://github.com/google/googletest/archive/refs/tags/release-1.11.0.tar.gz | tar zx --strip-components=1 -C gtest
-        cd build
-        cmake ../gtest -DBUILD_GMOCK=OFF -DCMAKE_CXX_COMPILER=clang++-12 -DCMAKE_CXX_FLAGS="-stdlib=libc++" -DCMAKE_SHARED_LINKER_FLAGS="-stdlib=libc++"
-        make -j 2
-        sudo make install
-        sudo ldconfig
-    - name: configure
-      run: |
-        autoreconf -fi
-        PKG_CONFIG_PATH=/usr/local/lib/pkgconfig ./configure CC=clang-12 CXX=clang++-12 CXXFLAGS="-std=${{ matrix.standard }} -Wall -Werror -stdlib=libc++" LDFLAGS="-stdlib=libc++" || cat config.log
     - name: check ${{ matrix.standard }}
       run: make -j 2 check

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04]
+        os: [ubuntu-22.04]
         standard: [c++20]
         compiler: [g++-12]
 

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -14,18 +14,44 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-22.04]
-        standard: [c++20]
-        compiler: [g++-12]
+        os: [ubuntu-20.04]
+        standard: [c++11, c++14, c++17, c++20]
+        compiler: [g++-10, clang++-12]
 
     steps:
     - uses: actions/checkout@v3
     - name: Install gtest
       run: |
         sudo apt-get update
-        sudo apt-get install g++-12
         sudo apt-get install libgtest-dev
     - name: configure ${{ matrix.standard }}
       run: autoreconf -fi && ./configure CXX=${{ matrix.compiler }} CXXFLAGS="-std=${{ matrix.standard }} -Wall -Werror"
+    - name: check ${{ matrix.standard }}
+      run: make -j 2 check
+
+  test_libcxx:
+    name: Unit tests with clang and libc++
+    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        standard: [c++11, c++14, c++17, c++20]
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Install gtest
+      run: |
+        set -e
+        sudo apt install libc++-12-dev libc++1-12 libc++abi1-12 libc++abi-12-dev
+        mkdir gtest build
+        curl -L https://github.com/google/googletest/archive/refs/tags/release-1.11.0.tar.gz | tar zx --strip-components=1 -C gtest
+        cd build
+        cmake ../gtest -DBUILD_GMOCK=OFF -DCMAKE_CXX_COMPILER=clang++-12 -DCMAKE_CXX_FLAGS="-stdlib=libc++" -DCMAKE_SHARED_LINKER_FLAGS="-stdlib=libc++"
+        make -j 2
+        sudo make install
+        sudo ldconfig
+    - name: configure
+      run: |
+        autoreconf -fi
+        PKG_CONFIG_PATH=/usr/local/lib/pkgconfig ./configure CC=clang-12 CXX=clang++-12 CXXFLAGS="-std=${{ matrix.standard }} -Wall -Werror -stdlib=libc++" LDFLAGS="-stdlib=libc++" || cat config.log
     - name: check ${{ matrix.standard }}
       run: make -j 2 check

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         os: [ubuntu-20.04]
         standard: [c++11, c++14, c++17, c++20]
-        compiler: [g++-10, clang++-12]
+        compiler: [g++-12, clang++-12]
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -15,8 +15,8 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-20.04]
-        standard: [c++11, c++14, c++17, c++20]
-        compiler: [g++-12, clang++-12]
+        standard: [c++20]
+        compiler: [g++-12]
 
     steps:
     - uses: actions/checkout@v3
@@ -24,6 +24,7 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get install libgtest-dev
+        sudo apt-get install g++-12
     - name: configure ${{ matrix.standard }}
       run: autoreconf -fi && ./configure CXX=${{ matrix.compiler }} CXXFLAGS="-std=${{ matrix.standard }} -Wall -Werror"
     - name: check ${{ matrix.standard }}

--- a/include/compact_iterator.hpp
+++ b/include/compact_iterator.hpp
@@ -628,7 +628,7 @@ public:
   template<bool TS = false>
   void set_bits(W x, unsigned bits) {
     Derived& self  = *static_cast<Derived*>(this);
-    gs<W, BITS, W, UB>::set<TS>(x, self.m_ptr, bits, self.m_offset);
+    gs<W, BITS, W, UB>::template set<TS>(x, self.m_ptr, bits, self.m_offset);
   }
 
   // Get, i.e., don't use fetch


### PR DESCRIPTION
See #8 

The successful run with GCC 12 was here: https://github.com/Bouncner/compact_vector/actions/runs/4211382149

I did not want to propose changes to your GitHub actions (it's your account's credits in the end). But maybe GCC 10/12 and Clang 12/15 on a more recent Ubuntu 22.04 would be helpful to cover more compiler variations?

I can try to update the actions, if you agree on these changes.