### PR TITLE
Deallocate m_mem only if not nullptr

### DIFF
--- a/include/compact_vector.hpp
+++ b/include/compact_vector.hpp
@@ -95,7 +95,9 @@ public:
     : vector(0, 0, allocator)
   { }
   ~vector() {
-    m_allocator.deallocate(m_mem, elements_to_words(m_capacity, bits()));
+    if (m_mem) {
+      m_allocator.deallocate(m_mem, elements_to_words(m_capacity, bits()));
+    }
   }
 
   vector& operator=(const vector& rhs) {


### PR DESCRIPTION
The deconstructor [tries to deallocate memory](https://github.com/gmarcais/compact_vector/blob/9d5b66a4564582911780a9485765f61c74b95a4c/include/compact_vector.hpp#L98) for a given [nulltpr if the move constructor has been used before](https://github.com/gmarcais/compact_vector/blob/9d5b66a4564582911780a9485765f61c74b95a4c/include/compact_vector.hpp#L74). If the allocator is an `std::pmr::polymorphic_allocator`, the memory resource's `deallocate` function will be called with a nullptr. This is [undefined behavior](https://en.cppreference.com/w/cpp/memory/memory_resource/deallocate).

This PR adds a simple check so that the deconstructor only deallocates `m_mem` if it is not `nullptr`.